### PR TITLE
Feat/component/page

### DIFF
--- a/public/icon/ic-close.svg
+++ b/public/icon/ic-close.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.6568 12.657L1.34314 1.34326M12.6568 1.34326L1.34314 12.657" stroke="#1B1D1F" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/app/(providers)/layout.tsx
+++ b/src/app/(providers)/layout.tsx
@@ -1,12 +1,15 @@
 import { PropsWithChildren } from "react"
 import { AuthProvider } from "@/context/auth.context"
+import { ModalProvider } from "@/context/modal.context"
 import { TanstackQueryProvider } from "@/query/queryClient"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 
 export default function ProvidersLayout({ children }: PropsWithChildren) {
   return (
     <TanstackQueryProvider>
-      <AuthProvider>{children}</AuthProvider>
+      <AuthProvider>
+        <ModalProvider>{children}</ModalProvider>
+      </AuthProvider>
       <ReactQueryDevtools />
     </TanstackQueryProvider>
   )

--- a/src/app/(providers)/newsfeed/page.tsx
+++ b/src/app/(providers)/newsfeed/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react"
 import { useRouter } from "next/navigation"
+import { useModal } from "@/context/modal.context"
 import { useQuery } from "@tanstack/react-query"
 
 import Page from "@/components/Page"
@@ -18,6 +19,23 @@ function NewsfeedPage() {
   const [userId, setUserId] = useState<string>("")
   const [category, setCategory] = useState<string>("전체보기")
   const [searchQuery, setSearchQuery] = useState<string>("")
+
+  const modal = useModal()
+
+  const handleOpenAlertModal = () => {
+    modal.open({
+      type: "alert",
+      content: "알림 모달",
+    })
+  }
+
+  const handleOpenConfirmModal = () => {
+    modal.open({
+      type: "confirm",
+      content: "이건 확인 모달",
+      onConfirm: () => console.log("확인 버튼 클릭 시 적용될 로직 넣어주세요"),
+    })
+  }
 
   const router = useRouter()
 
@@ -60,6 +78,9 @@ function NewsfeedPage() {
         category={category}
         onSelectCategory={handleCategoryClick}
       />
+
+      <button onClick={handleOpenAlertModal}>알림 모달 열기</button>
+      <button onClick={handleOpenConfirmModal}>확인 모달 열기</button>
 
       {/* 검색 필터 */}
       <SearchFilter onSearch={handleSearch} />

--- a/src/app/(providers)/newsfeed/page.tsx
+++ b/src/app/(providers)/newsfeed/page.tsx
@@ -4,6 +4,8 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { useQuery } from "@tanstack/react-query"
 
+import Page from "@/components/Page"
+
 import { PostType } from "../../../../types/challenge"
 import CategorySelector from "./_components/CategorySelector"
 import ChallengePosts from "./_components/ChallengePosts"
@@ -52,8 +54,7 @@ function NewsfeedPage() {
   }
 
   return (
-    <div>
-      <h2>뉴스피드 페이지</h2>
+    <Page title="뉴스피드 페이지">
       {/* 카테고리 */}
       <CategorySelector
         category={category}
@@ -68,7 +69,7 @@ function NewsfeedPage() {
 
       {/* 목록 */}
       <ChallengePosts posts={posts} onClickPost={handlePostClick} />
-    </div>
+    </Page>
   )
 }
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,7 +1,32 @@
-import React from "react"
+"use client"
 
-function Input() {
-  return <div>Input</div>
+import { ComponentProps, useId } from "react"
+
+type InputProps = {
+  label?: string
+  required?: boolean
+} & ComponentProps<"input">
+
+function Input({ label, required, id, ...props }: InputProps) {
+  const inputUid = useId()
+  const inputId = id || inputUid
+
+  return (
+    <div className="flex flex-col gap-y-1.5 [&+&]:mt-4">
+      <label htmlFor={inputId}>
+        <span>{label}</span>
+        {required && (
+          <span className="text-sm font-semibold text-red-500">*</span>
+        )}
+      </label>
+      <input
+        className="rounded border border-gray-400 px-4 py-2.5 transition focus:border-gray-950 focus:outline-none"
+        type="text"
+        id={inputId}
+        {...props}
+      />
+    </div>
+  )
 }
 
 export default Input

--- a/src/components/Modal/BackDrop.tsx
+++ b/src/components/Modal/BackDrop.tsx
@@ -1,0 +1,11 @@
+import { PropsWithChildren } from "react"
+
+function BackDrop({ children }: PropsWithChildren) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 top-0 z-10 flex items-center justify-center bg-black/60">
+      {children}
+    </div>
+  )
+}
+
+export default BackDrop

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,57 @@
+import Image from "next/image"
+import { useModal } from "@/context/modal.context"
+
+import BackDrop from "./BackDrop"
+
+interface ModalProps {
+  type: "alert" | "confirm"
+  content: string
+  onConfirm?: () => void
+}
+
+function Modal({ type, content, onConfirm }: ModalProps) {
+  const modal = useModal()
+
+  const handleCloseModal = () => {
+    modal.close()
+  }
+
+  return (
+    <BackDrop>
+      <div className="relative min-w-[300px] rounded bg-white p-4">
+        <button onClick={handleCloseModal}>
+          <Image
+            width={10}
+            height={10}
+            src="/icon/ic-close.svg"
+            alt="Modal close icon"
+            className="absolute right-2 top-2 hidden sm:block"
+          />
+        </button>
+
+        <div className="flex flex-col items-center justify-center">
+          <p className="text-black">{content}</p>
+
+          <div className="mt-4 flex justify-around space-x-2">
+            <button
+              onClick={handleCloseModal}
+              className="border border-slate-600 px-6 py-2 text-black"
+            >
+              {type === "alert" ? "확인" : "취소"}
+            </button>
+            {type === "confirm" && (
+              <button
+                onClick={onConfirm}
+                className="border border-slate-600 px-6 py-2 text-black"
+              >
+                확인
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </BackDrop>
+  )
+}
+
+export default Modal

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -1,0 +1,28 @@
+import { PropsWithChildren } from "react"
+
+interface PageProps {
+  title: string
+  isTitleHidden?: boolean
+}
+
+const Page = ({
+  children,
+  title,
+  isTitleHidden,
+}: PropsWithChildren<PageProps>) => {
+  return (
+    <main className="container mx-auto p-4 sm:p-8 md:p-12 lg:p-14">
+      <h1
+        className={`font-semibold ${isTitleHidden ? "hidden" : ""} text-lg md:text-2xl lg:text-3xl`}
+      >
+        {title}
+      </h1>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-none lg:grid-cols-none">
+        {children}
+      </div>
+    </main>
+  )
+}
+
+export default Page

--- a/src/components/Page/index.ts
+++ b/src/components/Page/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Page"

--- a/src/context/modal.context.tsx
+++ b/src/context/modal.context.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { createContext, PropsWithChildren, useContext, useState } from "react"
+
+import Modal from "@/components/Modal/Modal"
+
+interface ModalProps {
+  type: "alert" | "confirm"
+  content: string
+  onConfirm?: () => void
+}
+
+interface ModalContextProps {
+  open: (option: ModalProps) => void
+  close: () => void
+  modalOptions: ModalProps | null
+}
+
+const initialModalValue: ModalContextProps = {
+  open: () => {},
+  close: () => {},
+  modalOptions: null,
+}
+
+const ModalContext = createContext<ModalContextProps>(initialModalValue)
+
+export const useModal = () => useContext(ModalContext)
+
+export const ModalProvider = ({ children }: PropsWithChildren) => {
+  const [modalOptions, setModalOptions] = useState<ModalProps | null>(null)
+
+  const open = (options: ModalProps) => {
+    const addedOption = {
+      ...options,
+      onConfirm: () => {
+        if (options.onConfirm) options.onConfirm()
+        close()
+      },
+    }
+
+    setModalOptions(addedOption)
+  }
+
+  const close = () => {
+    setModalOptions(null)
+  }
+
+  const value = {
+    open,
+    close,
+    modalOptions,
+  }
+
+  return (
+    <ModalContext.Provider value={value}>
+      {children}
+      {modalOptions && <Modal {...modalOptions} />}
+    </ModalContext.Provider>
+  )
+}


### PR DESCRIPTION
## 🔎 작업 내용

  - 모달(모달 컨텍스트 포함) 세팅
  - 공통 컴포넌트(page, input) 세팅
  <br/>

## 주의 사항
  
- 모달 호출 방법
  const modal = useModal()

  const handleOpenAlertModal = () => {
    modal.open({
      type: "alert",
      content: "알림 모달",
    })
  }

  const handleOpenConfirmModal = () => {
    modal.open({
      type: "confirm",
      content: "이건 확인 모달",
      onConfirm: () => console.log("확인 버튼 클릭 시 적용될 로직 넣어주세요"),
    })
  }

현재 newsfeed의 페이지에 모달 테스트한 부분이 있습니다

<br/>
